### PR TITLE
Use correct syntax highlight for copy-pasteable config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,10 @@ npm install --save-dev stylelint @thibaudcolas/stylelint-config-cookbook
 
 Then [configure stylelint to use this config](https://stylelint.io/user-guide/configuration/#extends). As a `stylelint.config.js` in the root of your project:
 
-```json
-"use strict";
-
+```js
 module.exports = {
   // https://github.com/thibaudcolas/stylelint-config-cookbook
-  extends: "@thibaudcolas/stylelint-config-cookbook"
+  extends: "@thibaudcolas/stylelint-config-cookbook",
 };
 ```
 


### PR DESCRIPTION
Makes the config easier to copy-paste. Also a test of the semantic-release setup from #7.