### PR TITLE
feat(config): enforce scss/at-mixin-named-arguments: always

### DIFF
--- a/src/__snapshots__/semver.test.js.snap
+++ b/src/__snapshots__/semver.test.js.snap
@@ -242,6 +242,9 @@ Object {
   "scss/at-function-named-arguments": Array [
     "always",
   ],
+  "scss/at-mixin-named-arguments": Array [
+    "always",
+  ],
   "scss/at-rule-no-unknown": Array [
     true,
   ],

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,7 @@ module.exports = {
     "scss/selector-no-redundant-nesting-selector": true,
     "scss/percent-placeholder-pattern": "^do-not-use-placeholders$",
     "scss/at-function-named-arguments": "always",
+    "scss/at-mixin-named-arguments": "always",
     "plugin/declaration-block-no-ignored-properties": true,
     "scale-unlimited/declaration-strict-value": [
       ["/color/", "z-index", "font-size", "font-family"],


### PR DESCRIPTION
BREAKING CHANGE: now enforces mixins always using named arguments via [`scss/at-mixin-named-arguments`](https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/at-mixin-named-arguments).
This is similar to [`scss/at-function-named-arguments`](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/at-mixin-named-arguments/).

Error:

```scss
.foo {
  @include animation(250ms, 100ms);
}
```

Success:

```scss
.foo {
  @include animation($duration: 250ms, $delay: 100ms);
}
```