### PR TITLE
Remove Prettier enforcement with stylelint-prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4662,15 +4662,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
-      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
-      "requires": {
-        "fast-diff": "^1.1.1",
-        "jest-docblock": "^21.0.0"
-      }
-    },
     "eslint-scope": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
@@ -4870,11 +4861,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-    },
-    "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "fast-glob": {
       "version": "2.2.2",
@@ -7518,11 +7504,6 @@
         "jest-get-type": "^22.1.0",
         "pretty-format": "^23.5.0"
       }
-    },
-    "jest-docblock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw=="
     },
     "jest-each": {
       "version": "23.5.0",
@@ -15563,14 +15544,6 @@
             "yargs-parser": "^7.0.0"
           }
         }
-      }
-    },
-    "stylelint-prettier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-1.0.1.tgz",
-      "integrity": "sha512-qM4Cs7JEWw/eLNsP04WDkQ2xCu3YXIjMivG/Pb+Nn91FbhRWVw5WbwucJKPnI1tciVesdXOT9x7AoiWp+thm1g==",
-      "requires": {
-        "eslint-plugin-prettier": "^2.6.2"
       }
     },
     "stylelint-scss": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "stylelint-declaration-block-no-ignored-properties": "^1.1.0",
     "stylelint-declaration-strict-value": "^1.0.4",
     "stylelint-no-unsupported-browser-features": "^3.0.1",
-    "stylelint-prettier": "^1.0.1",
     "stylelint-scss": "^3.3.0"
   },
   "peerDependencies": {

--- a/src/__snapshots__/semver.test.js.snap
+++ b/src/__snapshots__/semver.test.js.snap
@@ -213,9 +213,6 @@ Object {
       ],
     },
   ],
-  "prettier/prettier": Array [
-    true,
-  ],
   "property-case": null,
   "property-no-unknown": Array [
     true,

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,6 @@ module.exports = {
     "stylelint-declaration-block-no-ignored-properties",
     "stylelint-declaration-strict-value",
     "stylelint-no-unsupported-browser-features",
-    "stylelint-prettier",
   ],
   rules: {
     "color-named": "never",
@@ -51,6 +50,5 @@ module.exports = {
         ],
       },
     ],
-    "prettier/prettier": true,
   },
 };

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -13,7 +13,7 @@ describe("config", () => {
         configFile: path.join(__dirname, "config.js"),
       })
       .then(results => {
-        expect(results.results[0].warnings.length).toBe(10);
+        expect(results.results[0].warnings.length).toBe(9);
       });
   });
 });

--- a/src/semver.test.js
+++ b/src/semver.test.js
@@ -12,7 +12,6 @@ Object {
   "stylelint-declaration-block-no-ignored-properties": "^1.1.0",
   "stylelint-declaration-strict-value": "^1.0.4",
   "stylelint-no-unsupported-browser-features": "^3.0.1",
-  "stylelint-prettier": "^1.0.1",
   "stylelint-scss": "^3.3.0",
 }
 `);


### PR DESCRIPTION
Removes stylelint-prettier and its prettier/prettier rule. This makes it possible for projects to use this config even if they do not use Prettier. Projects that do use Prettier should use it separately to check files follow its formatting (`prettier --list-different`).