### PR TITLE
feat(config): enforce 4 additional SCSS rules

### DIFF
--- a/src/__snapshots__/semver.test.js.snap
+++ b/src/__snapshots__/semver.test.js.snap
@@ -239,6 +239,9 @@ Object {
   "scss/at-function-named-arguments": Array [
     "always",
   ],
+  "scss/at-mixin-argumentless-call-parentheses": Array [
+    "always",
+  ],
   "scss/at-mixin-named-arguments": Array [
     "always",
   ],
@@ -247,6 +250,15 @@ Object {
   ],
   "scss/declaration-nested-properties": Array [
     "never",
+  ],
+  "scss/dollar-variable-no-missing-interpolation": Array [
+    true,
+  ],
+  "scss/media-feature-value-dollar-variable": Array [
+    true,
+  ],
+  "scss/no-duplicate-dollar-variables": Array [
+    true,
   ],
   "scss/percent-placeholder-pattern": Array [
     "^do-not-use-placeholders$",

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,10 @@ module.exports = {
     "scss/percent-placeholder-pattern": "^do-not-use-placeholders$",
     "scss/at-function-named-arguments": "always",
     "scss/at-mixin-named-arguments": "always",
+    "scss/dollar-variable-no-missing-interpolation": true,
+    "scss/at-mixin-argumentless-call-parentheses": "always",
+    "scss/media-feature-value-dollar-variable": true,
+    "scss/no-duplicate-dollar-variables": true,
     "plugin/declaration-block-no-ignored-properties": true,
     "scale-unlimited/declaration-strict-value": [
       ["/color/", "z-index", "font-size", "font-family"],


### PR DESCRIPTION
BREAKING CHANGE: enforces 4 additional SCSS rules,

- [`scss/dollar-variable-no-missing-interpolation`](https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/dollar-variable-no-missing-interpolation) – prevents this type of error in stylesheets.
- [`scss/at-mixin-argumentless-call-parentheses`](https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/at-mixin-argumentless-call-parentheses) – makes @include statements more consistent between argumentless and with-arguments.
- [`scss/media-feature-value-dollar-variable`](https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/media-feature-value-dollar-variable) – makes it harder to declare @media rules with arbitrary values.
- [`scss/no-duplicate-dollar-variables`](https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/no-duplicate-dollar-variables) – code smell check.