### PR TITLE
Fix recent rules introduction (#15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15547,9 +15547,9 @@
       }
     },
     "stylelint-scss": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.3.0.tgz",
-      "integrity": "sha512-1E54Tsx/RPJDbGqLK8LcCUa62dB+KRg4zhqo/ub38PBpf16qz5mY/6VJCkQHSU3MygyyJDiFf/J5TLLznrRmGA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.3.1.tgz",
+      "integrity": "sha512-jPyxkFQh9nk4DIs8lUKCRjlkKSsaqMUQwwZ10Y0fvWB50Lk0QnW6nezhmeYtRR7wZJq8iNTYeYOTyU8chRSoBQ==",
       "requires": {
         "lodash": "^4.17.10",
         "postcss-media-query-parser": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "stylelint-declaration-block-no-ignored-properties": "^1.1.0",
     "stylelint-declaration-strict-value": "^1.0.4",
     "stylelint-no-unsupported-browser-features": "^3.0.1",
-    "stylelint-scss": "^3.3.0"
+    "stylelint-scss": "^3.3.1"
   },
   "peerDependencies": {
     "stylelint": "^9.5.0"

--- a/src/__snapshots__/semver.test.js.snap
+++ b/src/__snapshots__/semver.test.js.snap
@@ -255,7 +255,7 @@ Object {
     true,
   ],
   "scss/media-feature-value-dollar-variable": Array [
-    true,
+    "always",
   ],
   "scss/no-duplicate-dollar-variables": Array [
     true,

--- a/src/config.js
+++ b/src/config.js
@@ -33,7 +33,7 @@ module.exports = {
     "scss/at-mixin-named-arguments": "always",
     "scss/dollar-variable-no-missing-interpolation": true,
     "scss/at-mixin-argumentless-call-parentheses": "always",
-    "scss/media-feature-value-dollar-variable": true,
+    "scss/media-feature-value-dollar-variable": "always",
     "scss/no-duplicate-dollar-variables": true,
     "plugin/declaration-block-no-ignored-properties": true,
     "scale-unlimited/declaration-strict-value": [

--- a/src/semver.test.js
+++ b/src/semver.test.js
@@ -12,7 +12,7 @@ Object {
   "stylelint-declaration-block-no-ignored-properties": "^1.1.0",
   "stylelint-declaration-strict-value": "^1.0.4",
   "stylelint-no-unsupported-browser-features": "^3.0.1",
-  "stylelint-scss": "^3.3.0",
+  "stylelint-scss": "^3.3.1",
 }
 `);
   });


### PR DESCRIPTION
Includes fixes for two rules introduced in #15:

- One wasn't using the right value (true vs `always`)
- `scss/at-function-named-arguments` had a bug with trailing commas